### PR TITLE
31 add golangci and audit to actions

### DIFF
--- a/.github/workflows/constraint-service-ci.yaml
+++ b/.github/workflows/constraint-service-ci.yaml
@@ -1,4 +1,4 @@
-name: container-service - build, test and push image
+name: constraint-service
 
 on:
   push:
@@ -29,13 +29,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VER }}
           cache-dependency-path: go.sum
-      - name: Setup Task
+      - name: Setup Taskfile
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
       - name: Display Go version
         run: go version
       - name: Install dependencies
         run: task build
-      - name: Run tests
+      - name: Run test task
         run: task test
 
   golangci:
@@ -48,11 +48,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VER }}
           cache-dependency-path: go.sum
-      - name: Setup Task
+      - name: Setup Taskfile
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
       - name: Display Go version
         run: go version
-      - name: golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
@@ -67,11 +67,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VER }}
           cache-dependency-path: go.sum
-      - name: Setup Task
+      - name: Setup Taskfile
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
       - name: Display Go version
         run: go version
-      - name: Install dependencies
+      - name: Run audit task
         run: task audit-ci
 
   docker:

--- a/.github/workflows/constraint-service-ci.yaml
+++ b/.github/workflows/constraint-service-ci.yaml
@@ -2,26 +2,26 @@ name: container-service - build, test and push image
 
 on:
   push:
-    paths: 
+    paths:
       - src/constraint-service/**
-  pull_request: 
-    paths: 
+  pull_request:
+    paths:
       - src/constraint-service/**
-  workflow_dispatch: 
+  workflow_dispatch:
 
 env:
-  GO_VER: '1.22.5'
+  GO_VER: "1.22.5"
   APP_NAME: constraint-service
   REGISTRY: ghcr.io
 
 defaults:
   run:
-     working-directory: ./src/constraint-service
+    working-directory: ./src/constraint-service
 
 jobs:
   test:
+    name: run tests
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ env.GO_VER }}
@@ -37,6 +37,42 @@ jobs:
         run: task build
       - name: Run tests
         run: task test
+
+  golangci:
+    name: code quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ env.GO_VER }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VER }}
+          cache-dependency-path: go.sum
+      - name: Setup Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Display Go version
+        run: go version
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+
+  audit:
+    name: audit code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ env.GO_VER }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VER }}
+          cache-dependency-path: go.sum
+      - name: Setup Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Display Go version
+        run: go version
+      - name: Install dependencies
+        run: task audit-ci
 
   docker:
     runs-on: ubuntu-latest
@@ -77,5 +113,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-        
-

--- a/.github/workflows/constraint-service-ci.yaml
+++ b/.github/workflows/constraint-service-ci.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Run test task
         run: task test
 
-  golangci:
-    name: code quality
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +56,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
+          working-directory: ./src/constraint-service
 
   audit:
     name: audit code

--- a/.github/workflows/constraint-service-ci.yaml
+++ b/.github/workflows/constraint-service-ci.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VER: "1.22.5"
+  GO_VER: "1.23.1"
   APP_NAME: constraint-service
   REGISTRY: ghcr.io
 

--- a/src/constraint-service/Taskfile.yml
+++ b/src/constraint-service/Taskfile.yml
@@ -16,6 +16,9 @@ tasks:
     cmds:
       - go mod tidy -v
       - go fmt ./...
+  lint:
+    cmds:
+      - go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run
   build:
     cmds:
       - go build -o /tmp/bin/{{.BINARY_NAME}} {{.MAIN_PACKAGE}}

--- a/src/constraint-service/Taskfile.yml
+++ b/src/constraint-service/Taskfile.yml
@@ -11,7 +11,7 @@ tasks:
     env:
       CGO_ENABLED: 1
     cmds:
-      - go test -v -race -buildvcs ./...
+      - go run gotest.tools/gotestsum@latest --format testname -- -v -race -buildvcs ./...
   tidy:
     cmds:
       - go mod tidy -v

--- a/src/constraint-service/Taskfile.yml
+++ b/src/constraint-service/Taskfile.yml
@@ -37,9 +37,7 @@ tasks:
     cmds:
       - go build -o /tmp/bin/{{.BINARY_NAME}} {{.MAIN_PACKAGE}}
       - /tmp/bin/{{.BINARY_NAME}}
-  audit:
-    deps:
-      - test
+  audit-ci:
     cmds:
       - go mod tidy -diff
       - go mod verify
@@ -47,6 +45,10 @@ tasks:
       - go vet ./...
       - go run honnef.co/go/tools/cmd/staticcheck@latest -checks=all,-ST1000,-U1000,-ST1003 ./...
       - go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+  audit:
+    deps:
+      - test
+      - audit-ci
   no-dirty:
     cmds:
       - test -z "$(git status --porcelain)"

--- a/src/constraint-service/cmd/server/server.go
+++ b/src/constraint-service/cmd/server/server.go
@@ -68,10 +68,17 @@ func main() {
 	http.HandleFunc("/health", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/text")
 		w.WriteHeader(http.StatusOK)
-		io.WriteString(w, "OK")
+
+		if _, err := io.WriteString(w, "OK"); err != nil {
+			log.Fatalf("/health handler failed to write response: %v", err)
+		}
 	}))
 
-	go http.ListenAndServe(":"+strconv.Itoa(conf.HeartbeatPort), nil)
+	go func() {
+		if err := http.ListenAndServe(":"+strconv.Itoa(conf.HeartbeatPort), nil); err != nil {
+			log.Fatalf("failed to listen on port %d: %v", conf.HeartbeatPort, err)
+		}
+	}()
 
 	if conf.UseReflection {
 		reflection.Register(s)

--- a/src/constraint-service/go.mod
+++ b/src/constraint-service/go.mod
@@ -1,8 +1,6 @@
 module github.com/pavozayac/scheduling/src/constraint-service
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.1
 
 require (
 	github.com/99designs/gqlgen v0.17.54

--- a/src/constraint-service/internal/application/services/location.go
+++ b/src/constraint-service/internal/application/services/location.go
@@ -23,10 +23,14 @@ func (s *locationService) CreateOrModifyLocation(ctx context.Context, dto ports.
 	if dto.Id == "" {
 		id = shared.UuidGenerator{}.Generate()
 	} else {
-		id.Scan(dto.Id)
+		if err := id.Scan(dto.Id); err != nil {
+			return nil, err
+		}
 	}
 
-	scheduleId.Scan(dto.ScheduleId)
+	if err := scheduleId.Scan(dto.ScheduleId); err != nil {
+		return nil, err
+	}
 
 	location, err := model.NewLocation(id, scheduleId, dto.Name, dto.Description)
 	if err != nil {
@@ -48,7 +52,9 @@ func (s *locationService) CreateOrModifyLocation(ctx context.Context, dto ports.
 
 func (s *locationService) GetLocation(ctx context.Context, id string) (*ports.LocationDTO, error) {
 	var locationId shared.Identity
-	locationId.Scan(id)
+	if err := locationId.Scan(id); err != nil {
+		return nil, err
+	}
 
 	location, err := s.repo.GetLocation(ctx, locationId)
 	if err != nil {
@@ -67,7 +73,9 @@ func (s *locationService) GetLocation(ctx context.Context, id string) (*ports.Lo
 
 func (s *locationService) RemoveLocation(ctx context.Context, id string) error {
 	var locationId shared.Identity
-	locationId.Scan(id)
+	if err := locationId.Scan(id); err != nil {
+		return err
+	}
 
 	return s.repo.DeleteLocation(ctx, locationId)
 }

--- a/src/constraint-service/internal/application/services/schedule.go
+++ b/src/constraint-service/internal/application/services/schedule.go
@@ -106,7 +106,9 @@ func (s *scheduleService) GetSchedule(ctx context.Context, id string) (*ports.Sc
 
 func (s *scheduleService) RemoveSchedule(ctx context.Context, id string) error {
 	var scheduleId shared.Identity
-	scheduleId.Scan(id)
+	if err := scheduleId.Scan(id); err != nil {
+		return fmt.Errorf("scheduleId.Scan() error: %w", err)
+	}
 
 	return s.repo.DeleteSchedule(ctx, scheduleId)
 }

--- a/src/constraint-service/internal/application/services/task.go
+++ b/src/constraint-service/internal/application/services/task.go
@@ -23,10 +23,14 @@ func (s *taskService) CreateOrModifyTask(ctx context.Context, dto ports.TaskDTO)
 	if dto.Id == "" {
 		id = shared.UuidGenerator{}.Generate()
 	} else {
-		id.Scan(dto.Id)
+		if err := id.Scan(dto.Id); err != nil {
+			return nil, err
+		}
 	}
 
-	scheduleId.Scan(dto.ScheduleId)
+	if err := scheduleId.Scan(dto.ScheduleId); err != nil {
+		return nil, err
+	}
 
 	task, err := model.NewTask(id, scheduleId, dto.Title, dto.Description)
 	if err != nil {
@@ -48,7 +52,9 @@ func (s *taskService) CreateOrModifyTask(ctx context.Context, dto ports.TaskDTO)
 
 func (s *taskService) GetTask(ctx context.Context, id string) (*ports.TaskDTO, error) {
 	var taskId shared.Identity
-	taskId.Scan(id)
+	if err := taskId.Scan(id); err != nil {
+		return nil, err
+	}
 
 	task, err := s.repo.GetTask(ctx, taskId)
 	if err != nil {
@@ -65,7 +71,9 @@ func (s *taskService) GetTask(ctx context.Context, id string) (*ports.TaskDTO, e
 
 func (s *taskService) RemoveTask(ctx context.Context, id string) error {
 	var taskId shared.Identity
-	taskId.Scan(id)
+	if err := taskId.Scan(id); err != nil {
+		return err
+	}
 
 	return s.repo.DeleteTask(ctx, taskId)
 }

--- a/src/constraint-service/internal/application/services/worker.go
+++ b/src/constraint-service/internal/application/services/worker.go
@@ -23,10 +23,14 @@ func (s *workerService) CreateOrModifyWorker(ctx context.Context, dto ports.Work
 	if dto.Id == "" {
 		id = shared.UuidGenerator{}.Generate()
 	} else {
-		id.Scan(dto.Id)
+		if err := id.Scan(dto.Id); err != nil {
+			return nil, err
+		}
 	}
 
-	scheduleId.Scan(dto.ScheduleId)
+	if err := scheduleId.Scan(dto.ScheduleId); err != nil {
+		return nil, err
+	}
 
 	worker, err := model.NewWorker(id, scheduleId, dto.FirstName, dto.LastName)
 	if err != nil {
@@ -48,7 +52,9 @@ func (s *workerService) CreateOrModifyWorker(ctx context.Context, dto ports.Work
 
 func (s *workerService) GetWorker(ctx context.Context, id string) (*ports.WorkerDTO, error) {
 	var workerId shared.Identity
-	workerId.Scan(id)
+	if err := workerId.Scan(id); err != nil {
+		return nil, err
+	}
 
 	worker, err := s.repo.GetWorker(ctx, workerId)
 	if err != nil {
@@ -65,7 +71,9 @@ func (s *workerService) GetWorker(ctx context.Context, id string) (*ports.Worker
 
 func (s *workerService) RemoveWorker(ctx context.Context, id string) error {
 	var workerId shared.Identity
-	workerId.Scan(id)
+	if err := workerId.Scan(id); err != nil {
+		return err
+	}
 
 	return s.repo.DeleteWorker(ctx, workerId)
 }

--- a/src/constraint-service/internal/domain/model/constraint_test.go
+++ b/src/constraint-service/internal/domain/model/constraint_test.go
@@ -7,18 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type Input struct {
-	scheduleId shared.Identity
-	firstArg   shared.Identity
-	secondArg  shared.Identity
-	thirdArg   ConstraintType
-}
-
-type Output struct {
-	expectedConstraint Constraint
-	expectedError      error
-}
-
 var mockId1 = shared.MockIdentityGenerator{}.Generate()
 var mockId2 = shared.MockIdentityGenerator{}.Generate()
 var mockId3 = shared.MockIdentityGenerator{}.Generate()

--- a/src/constraint-service/internal/infrastructure/adapters/psql_location_repo.go
+++ b/src/constraint-service/internal/infrastructure/adapters/psql_location_repo.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -39,13 +40,15 @@ func (r *PsqlLocationRepo) SaveOrUpdateLocation(ctx context.Context, location mo
 	})
 }
 
-func (r *PsqlLocationRepo) GetLocation(ctx context.Context, id shared.Identity) (*model.Location, error) {
+func (r *PsqlLocationRepo) GetLocation(ctx context.Context, id shared.Identity) (location *model.Location, err error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	defer tx.Rollback(ctx)
+	defer func() {
+		err = errors.Join(err, tx.Rollback(ctx))
+	}()
 
 	queries := sqlc.New(tx)
 

--- a/src/constraint-service/internal/infrastructure/adapters/psql_task_repo.go
+++ b/src/constraint-service/internal/infrastructure/adapters/psql_task_repo.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -38,13 +39,15 @@ func (r *PsqlTaskRepo) SaveOrUpdateTask(ctx context.Context, task model.Task) er
 	})
 }
 
-func (r *PsqlTaskRepo) GetTask(ctx context.Context, id shared.Identity) (*model.Task, error) {
+func (r *PsqlTaskRepo) GetTask(ctx context.Context, id shared.Identity) (task *model.Task, err error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	defer tx.Rollback(ctx)
+	defer func() {
+		err = errors.Join(err, tx.Rollback(ctx))
+	}()
 
 	queries := sqlc.New(tx)
 

--- a/src/constraint-service/internal/infrastructure/adapters/psql_worker_repo.go
+++ b/src/constraint-service/internal/infrastructure/adapters/psql_worker_repo.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -37,13 +38,15 @@ func (r *PsqlWorkerRepo) SaveOrUpdateWorker(ctx context.Context, worker model.Wo
 	})
 }
 
-func (r *PsqlWorkerRepo) GetWorker(ctx context.Context, id shared.Identity) (*model.Worker, error) {
+func (r *PsqlWorkerRepo) GetWorker(ctx context.Context, id shared.Identity) (worker *model.Worker, err error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	defer tx.Rollback(ctx)
+	defer func() {
+		err = errors.Join(err, tx.Rollback(ctx))
+	}()
 
 	queries := sqlc.New(tx)
 

--- a/src/constraint-service/internal/infrastructure/shared/transactions.go
+++ b/src/constraint-service/internal/infrastructure/shared/transactions.go
@@ -22,7 +22,10 @@ func TransactionDecorator(ctx context.Context, r PsqlDatabaser, queryFunc QueryF
 	}
 
 	defer func() {
-		err = errors.Join(err, tx.Rollback(ctx))
+		tempErr := tx.Rollback(ctx)
+		if !errors.Is(tempErr, pgx.ErrTxClosed) {
+			err = errors.Join(err, tempErr)
+		}
 	}()
 
 	queries := sqlc.New(tx)

--- a/src/constraint-service/internal/infrastructure/shared/transactions.go
+++ b/src/constraint-service/internal/infrastructure/shared/transactions.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/pavozayac/scheduling/src/constraint-service/internal/infrastructure/db/sqlc"
@@ -13,14 +14,16 @@ type PsqlDatabaser interface {
 
 type QueryFunc func(*sqlc.Queries, context.Context) error
 
-func TransactionDecorator(ctx context.Context, r PsqlDatabaser, queryFunc QueryFunc) error {
+func TransactionDecorator(ctx context.Context, r PsqlDatabaser, queryFunc QueryFunc) (err error) {
 	db := r.Db()
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		return err
 	}
 
-	defer tx.Rollback(ctx)
+	defer func() {
+		err = errors.Join(err, tx.Rollback(ctx))
+	}()
 
 	queries := sqlc.New(tx)
 


### PR DESCRIPTION
# Changes
- Add golangci job
- Add audit to be a ci job
- Fix linter errors
- Fix missing error check on TransactionDecorator, where the return value of the deferred tx.Rollback was initially not checked, but should error with pgx.ErrTxClosed after sucessful completion of all operations


Closes #31.